### PR TITLE
Change instagram tiles to 320px

### DIFF
--- a/src/components/style.css
+++ b/src/components/style.css
@@ -1,6 +1,6 @@
 .instagram-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 }
 
 .instagram-overlay {


### PR DESCRIPTION
In order to prevent horizontal scroll on smaller screens,

as discussed  #[here](https://github.com/LekoArts/gatsby-themes/issues/548)

